### PR TITLE
Re-add /maven-scala-tools-releases pointing to oss.sonatype.org

### DIFF
--- a/src/main/scala/com/heroku/s3pository/S3rver.scala
+++ b/src/main/scala/com/heroku/s3pository/S3rver.scala
@@ -27,7 +27,7 @@ object S3rver {
   val mavenSpringRoo = ProxiedRepository("/maven-spring-roo", "spring-roo-repository.springsource.org", "/release", s3prefix + "-proxy-spring-roo").include("/org/springframework/roo")
   val mavenJboss = ProxiedRepository("/maven-jboss", "repository.jboss.org", "/nexus/content/repositories/releases", s3prefix + "-proxy-jboss", 443, true).include("/jboss").include("/org/jboss").include("/javax/validation").include("/org/hibernate")
   val mavenSonatypeOss = ProxiedRepository("/maven-sonatype-oss", "oss.sonatype.org", "/content/repositories/snapshots", s3prefix + "-proxy-sonatype-snapshots").include("/com/force").include("/com/heroku")
-  val mavenSonatypeOssScalaTools = ProxiedRepository("/maven-sonatype-oss-scala-tools", "oss.sonatype.org", "/content/groups/scala-tools", s3prefix + "-proxy-sonatype-scala-tools")
+  val mavenSonatypeOssScalaTools = ProxiedRepository("/maven-scala-tools-releases", "oss.sonatype.org", "/content/groups/scala-tools", s3prefix + "-proxy-sonatype-scala-tools")
   val mavenDatanucleus = ProxiedRepository("/maven-datanucleus", "www.datanucleus.org", "/downloads/maven2", s3prefix + "-proxy-datanucleus").include("/org/datanucleus").include("/javax/jdo")
   val mavenTypesafeReleases = ProxiedRepository("/maven-typesafe-releases", "repo.typesafe.com", "/typesafe/maven-releases", s3prefix + "-proxy-typesafe-releases").include("/com/typesafe")
   val ivyTypesafeReleases = ProxiedRepository("/ivy-typesafe-releases", "repo.typesafe.com", "/typesafe/ivy-releases", s3prefix + "-proxy-typesafe-ivy-releases").include("/com.typesafe").include("/org.scala-tools.sbt").include("/org.scala-sbt")


### PR DESCRIPTION
Support for scala-tools in s3pository was dropped because of the repo sunsetting, but there are still artifacts that are only in scala-tools and not in Maven Central. This causes artifacts that can be resolved with a local, vanilla SBT to fail on pushes to Heroku. Instead of dropping all together, we should have pointed /maven-scala-tools-releases to https://oss.sonatype.org/content/groups/scala-tools/, per the note on http://scala-tools.org/.

We should also point /maven-scala-tools-snapshots to https://oss.sonatype.org/content/repositories/snapshots/ per the note, but holding off because it is already present under /maven-sonatype-oss, but only for .include("/com/force").include("/com/heroku"), so want to check if there is a reason for that.

Tested this with my staging s3pository using this buildpack:
BUILDPACK_URL=git://github.com/ryanbrainard/heroku-buildpack-scala.git#sbt-tools-sonatype-brainard
